### PR TITLE
displaying errors when compilation fails: fixes jkphl/grunt-svg-sprite#3...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .project
+/nbproject
 *.md.html
 **/*.md.html
 /.settings

--- a/tasks/svg_sprite.js
+++ b/tasks/svg_sprite.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
 			spriter.compile(function(error, result) {
 				console.log();
 				if (error) {
-					
+					grunt.fail.warn("SVG sprite compilation failed.\n" + error);
 				} else {
 					for (var mode in result) {
 						for (var resource in result[mode]) {


### PR DESCRIPTION
This line will at least print the error. When used without `--force`, it will stop grunt (because it's fail.warn). If used with `--force`, grunt will continue.

    Tomasz.Ducin@WAWLT548 ~/Tests/svg-sprite-test
    $ grunt --force
    Running "svg_sprite:basic" (svg_sprite) task
    
    Running "svg_sprite:basic2" (svg_sprite) task
    
    Warning: Sprite generation failed.
    ArgumentError: SVGSpriter.compile: "{}" is not a valid mode configuration Used --force, continuing.
    
    Running "svg_sprite:flags" (svg_sprite) task
    
    Warning: Sprite generation failed.
    ArgumentError: SVGSpriter.compile: "{}" is not a valid mode configuration Used --force, continuing.
    
    Done, but with warnings.
