### PR TITLE
Update package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document covers only Grunt specific installation and configuration aspects.
 
 ## Getting Started
 
-This plugin requires Grunt `~0.4.5`
+This plugin requires Grunt `>=0.4.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 

--- a/package.json
+++ b/package.json
@@ -1,69 +1,63 @@
 {
-	"name": "grunt-svg-sprite",
-	"description": "SVG sprites & stacks galore — Grunt plugin wrapping around svg-sprite that reads in a bunch of SVG files, optimizes them and creates SVG sprites and CSS resources in various flavours",
-	"version": "1.1.2",
-	"homepage": "https://github.com/jkphl/grunt-svg-sprite",
-	"author": {
-		"name": "Joschi Kuphal",
-		"email": "joschi@kuphal.net",
-		"url": "https://jkphl.is"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/jkphl/grunt-svg-sprite.git"
-	},
-	"bugs": {
-		"url": "https://github.com/jkphl/grunt-svg-sprite/issues"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "https://github.com/jkphl/grunt-svg-sprite/blob/master/LICENSE.txt"
-		}
-	],
-	"main": "Gruntfile.js",
-	"engines": {
-		"node": ">= 0.8.0"
-	},
-	"scripts": {
-		"test": "grunt test"
-	},
-	"dependencies": {
-		"svg-sprite": "^1.1.2",
-		"prettysize": "^0.0.3",
-		"chalk": "^1.0.0"
-	},
-	"devDependencies": {
-		"grunt-contrib-jshint": "^0.11.2",
-		"grunt-contrib-clean": "^0.6.0",
-		"grunt-contrib-nodeunit": "^0.4.1",
-		"grunt": "~0.4.5",
-		"svg2png": "^1.1.1",
-		"image-diff": "^1.0.1"
-	},
-	"peerDependencies": {
-		"grunt": "~0.4.5"
-	},
-	"keywords": [
-		"gruntplugin",
-		"icon",
-		"icons",
-		"svg",
-		"png",
-		"sprite",
-		"spritesheet",
-		"stack",
-		"generator",
-		"css",
-		"sass",
-		"less",
-		"stylus",
-		"stylesheet",
-		"inline",
-		"html",
-		"vector",
-		"rwd",
-		"retina",
-		"mustache"
-	]
+  "name": "grunt-svg-sprite",
+  "description": "SVG sprites & stacks galore — Grunt plugin wrapping around svg-sprite that reads in a bunch of SVG files, optimizes them and creates SVG sprites and CSS resources in various flavours",
+  "version": "1.1.2",
+  "homepage": "https://github.com/jkphl/grunt-svg-sprite",
+  "author": "Joschi Kuphal <joschi@kuphal.net> (https://jkphl.is)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jkphl/grunt-svg-sprite.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jkphl/grunt-svg-sprite/issues"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "files": [
+    "tasks",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "chalk": "^1.0.0",
+    "prettysize": "^0.0.3",
+    "svg-sprite": "^1.1.2"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-contrib-nodeunit": "^0.4.1",
+    "image-diff": "^1.0.1",
+    "svg2png": "^1.1.1"
+  },
+  "peerDependencies": {
+    "grunt": ">=0.4.0"
+  },
+  "keywords": [
+    "gruntplugin",
+    "icon",
+    "icons",
+    "svg",
+    "png",
+    "sprite",
+    "spritesheet",
+    "stack",
+    "generator",
+    "css",
+    "sass",
+    "less",
+    "stylus",
+    "stylesheet",
+    "inline",
+    "html",
+    "vector",
+    "rwd",
+    "retina",
+    "mustache"
+  ]
 }


### PR DESCRIPTION
* specify the files to install
* use the shorter `license` property
* remove moot `main` property
* make node.js 0.10 the minimum supported version; 0.8 wasn't being tests in CI

https://github.com/jkphl/grunt-svg-sprite/pull/48/files?w=1 for the no whitespace diff.